### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,4 +1,6 @@
 name: Specs
+permissions:
+  contents: read
 on:
 - pull_request
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/hlascelles/dememoize/security/code-scanning/1](https://github.com/hlascelles/dememoize/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow. This ensures that the workflow has only the minimal permissions required to perform its tasks, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
